### PR TITLE
Use a login shell for cronjob

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -68,7 +68,7 @@ class bandersnatch::mirror (
   }
 
   if $daily_snapshots {
-    $cron_command = "run-bandersnatch && run-bandersnatch-snapshotting ${mirror_root}/web ${snapshot_retention}"
+    $cron_command = "/bin/sh -l -c \"run-bandersnatch && run-bandersnatch-snapshotting ${mirror_root}/web ${snapshot_retention}\""
     file { '/usr/local/bin/run-bandersnatch-snapshotting':
       ensure => present,
       source => 'puppet:///modules/bandersnatch/run_snapshotting.sh',


### PR DESCRIPTION
This is to make sure the shell picks up all envinroment
variables, such as http_proxy, that might be needed for
mirroring to work.
